### PR TITLE
Attachement types fix

### DIFF
--- a/components/ContactForm.php
+++ b/components/ContactForm.php
@@ -117,7 +117,7 @@ class ContactForm extends ComponentBase
           ->subject('Contact from website')
           ->replyTo(post('email'), post('name'));
         if(Input::file('attachment')){
-          $m->attach(Input::file('attachment'));
+          $m->attach(Input::file('attachment'), ['as' => Input::file('attachment')->getClientOriginalName()]);
         }
       });
     }
@@ -134,7 +134,7 @@ class ContactForm extends ComponentBase
         $m->to(post('email'), post('name'))
           ->subject(Settings::instance()->auto_reply_subject);
         if(Settings::get('enable_auto_reply_attachment') && Input::file('attachment')){
-          $m->attach(Input::file('attachment'));
+          $m->attach(Input::file('attachment'), ['as' => Input::file('attachment')->getClientOriginalName()]);
         }
       });
     }


### PR DESCRIPTION
Attachments were always as .dat files in the actual version. This workaround fixes that.